### PR TITLE
COMN-256: Upgrade dependency and plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>open-source-parent</artifactId>
     <groupId>com.basistech</groupId>
-    <version>3.0.3-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Parent POM for Basis Technology open source components.</description>
     <name>open-source-parent</name>
@@ -63,7 +63,7 @@
         <bt.java.source>1.8</bt.java.source>
         <bt.java.target>1.8</bt.java.target>
         <buildtools.artifact>open-source-buildtools</buildtools.artifact>
-        <buildtools.version>2.0.0</buildtools.version>
+        <buildtools.version>3.0.0</buildtools.version>
         <jackson-datatype-guava.group>com.fasterxml.jackson.datatype</jackson-datatype-guava.group>
         <maven-gpg-plugin.phase>verify</maven-gpg-plugin.phase>
         <nexus-staging-plugin-internal-nexus-url>http://nexus.basistech.net:8081/nexus/</nexus-staging-plugin-internal-nexus-url>
@@ -82,27 +82,27 @@
         <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
         <maven-assembly-plugin.version>3.1.1</maven-assembly-plugin.version>
         <maven-bundle-plugin.version>3.5.0</maven-bundle-plugin.version>
-        <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+        <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
-        <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-enforcer-plugin-version>1.4.1</maven-enforcer-plugin-version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-        <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
-        <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
-        <maven-pmd-plugin.version>3.11.0</maven-pmd-plugin.version>
+        <maven-jar-plugin.version>3.1.2</maven-jar-plugin.version>
+        <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
+        <maven-pmd-plugin.version>3.12.0</maven-pmd-plugin.version>
         <maven-project-info-reports-plugin.version>3.0.0</maven-project-info-reports-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-scm-plugin.version>3.0.0</maven-scm-plugin.version>
         <maven-shade-plugin.version>3.2.1</maven-shade-plugin.version>
-        <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
-        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
-        <maven-war-plugin.version>3.2.2</maven-war-plugin.version>
-        <maven.scm.version>1.11.1</maven.scm.version>
+        <maven-site-plugin.version>3.8.2</maven-site-plugin.version>
+        <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-war-plugin.version>3.2.3</maven-war-plugin.version>
+        <maven.scm.version>1.11.2</maven.scm.version>
         <nexus-staging-plugin-version>1.6.8</nexus-staging-plugin-version>
         <wagon-ssh.version>3.3.2</wagon-ssh.version>
         <!-- versions for dependencies -->
@@ -110,18 +110,14 @@
         <bt-adm-version>2.5.3</bt-adm-version>
         <bt-common-api-version>37.0.1</bt-common-api-version>
         <!-- things we consume -->
-        <bt-args4j-version>2.32</bt-args4j-version>
-        <bt-commons-io-version>2.4</bt-commons-io-version>
+        <bt-args4j-version>2.33</bt-args4j-version>
+        <bt-commons-io-version>2.6</bt-commons-io-version>
         <bt-commons-lang-version>2.6</bt-commons-lang-version>
-        <bt-fastutil-version>6.6.1</bt-fastutil-version>
+        <bt-fastutil-version>8.3.0</bt-fastutil-version>
         <bt-guava-version>26.0-jre</bt-guava-version>
-        <bt-hamcrest-version>1.3</bt-hamcrest-version>
-        <bt-httpasyncclient-version>4.1.2</bt-httpasyncclient-version>
-        <bt-httpclient-version>4.5.2</bt-httpclient-version>
-        <bt-httpcore-version>4.4.5</bt-httpcore-version>
-        <bt-httpmime-version>4.5</bt-httpmime-version>
+        <bt-hamcrest-version>2.2</bt-hamcrest-version>
         <bt-icu4j-version>59.1</bt-icu4j-version>
-        <bt-jackson-version>2.9.8</bt-jackson-version>
+        <bt-jackson-version>2.10.0</bt-jackson-version>
         <bt-jarchivelib-version>0.9.100-basis</bt-jarchivelib-version>
         <bt-junit-version>4.12</bt-junit-version>
         <bt-liblinear-version>1.95</bt-liblinear-version>
@@ -129,13 +125,13 @@
         <bt-metrics-version>3.2.3</bt-metrics-version>
         <bt-opencsv-version>2.3</bt-opencsv-version>
         <bt-protobuf-version>3.6.1</bt-protobuf-version>
-        <bt-slf4j-version>1.7.5</bt-slf4j-version>
-        <bt-snakeyaml-version>1.23</bt-snakeyaml-version>
+        <bt-slf4j-version>1.7.28</bt-slf4j-version>
+        <bt-snakeyaml-version>1.25</bt-snakeyaml-version>
         <bt-stax2-api-version>3.1.4</bt-stax2-api-version>
-        <bt-tika-bundle-version>1.10</bt-tika-bundle-version>
-        <bt-tika-core-version>1.14</bt-tika-core-version>
-        <bt-tika-parsers-version>1.5</bt-tika-parsers-version>
-        <bt-woodstox-version>4.0.5</bt-woodstox-version>
+        <bt-tika-bundle-version>1.22</bt-tika-bundle-version>
+        <bt-tika-core-version>1.22</bt-tika-core-version>
+        <bt-tika-parsers-version>1.22</bt-tika-parsers-version>
+        <bt-woodstox-version>4.4.1</bt-woodstox-version>
     </properties>
     <build>
         <defaultGoal>install</defaultGoal>
@@ -391,7 +387,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>6.18</version>
+                            <version>8.25</version>
                             <exclusions>
                                 <!-- MCHECKSTYLE-156 -->
                                 <exclusion>
@@ -672,41 +668,6 @@
                 <groupId>net.sf.opencsv</groupId>
                 <artifactId>opencsv</artifactId>
                 <version>${bt-opencsv-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpasyncclient</artifactId>
-                <version>${bt-httpasyncclient-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpasyncclient-osgi</artifactId>
-                <version>${bt-httpasyncclient-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient</artifactId>
-                <version>${bt-httpclient-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpclient-osgi</artifactId>
-                <version>${bt-httpclient-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpcore</artifactId>
-                <version>${bt-httpcore-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpcore-osgi</artifactId>
-                <version>${bt-httpcore-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents</groupId>
-                <artifactId>httpmime</artifactId>
-                <version>${bt-httpmime-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.tika</groupId>


### PR DESCRIPTION
A few of these version changes are to avoid security vulnerabilities in old versions. The rest are just to keep up to date, on principle. I removed the `org.apache.httpcomponents` dependencies and their properties because I don’t think anything depends on them except Rosette, whose POM already declares its own versions. I didn’t upgrade ICU, even though we are far behind, because that could be too disruptive.