### PR TITLE
Add ID to developer for BND plugin.  Upgrade Checkstyle.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     </scm>
     <developers>
         <developer>
+            <id>Katsuya-Tomioka</id>
             <name>Katsuya Tomioka</name>
             <email>katsuya@basistech.com</email>
             <organization>Basis Technology Corp.</organization>
@@ -391,7 +392,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.25</version>
+                            <version>8.30</version>
                             <exclusions>
                                 <!-- MCHECKSTYLE-156 -->
                                 <exclusion>


### PR DESCRIPTION
- Checkstyle upgrade to address [CVE](https://github.com/checkstyle/checkstyle/issues/7468).
- Add Developer ID to address BND plugin warning:
```
Cannot consider developer in line '50' of file '/Users/seth/.m2/repository/com/basistech/open-source-parent/5.0.0/open-source-parent-5.0.0.pom' for bundle header 'Bundle-Developers' as it does not contain the mandatory id.

```